### PR TITLE
Revert "Enable concurrent mode in driver"

### DIFF
--- a/rtl8733b.mk
+++ b/rtl8733b.mk
@@ -1,9 +1,5 @@
 EXTRA_CFLAGS += -DCONFIG_RTL8733B
 
-# Enable concurrent mode in driver so we have two interfaces visible
-# and can do both STA and AP at the same time
-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE -DCONFIG_IFACE_NUMBER=2
-
 #ifeq ($(CONFIG_MP_INCLUDED), y)
 ### 8733B Default Enable VHT MP HW TX MODE ###
 #EXTRA_CFLAGS += -DCONFIG_MP_VHT_HW_TX_MODE


### PR DESCRIPTION
This reverts commit bdcbe1798b9cf93721a17454a39349f19b4d5c83.

Apparently dual mode is not working properly, even though only one mode at a time is active.
This actually doesn't solve any issue, simply do not use the faulty feature